### PR TITLE
Catch for UnicodeEncodeError in NameObject

### DIFF
--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -467,7 +467,7 @@ class NameObject(str, PdfObject):
         if debug: print(name)
         try:
             return NameObject(name.decode('utf-8'))
-        except UnicodeDecodeError as e:
+        except (UnicodeEncodeError, UnicodeDecodeError) as e:
             # Name objects should represent irregular characters
             # with a '#' followed by the symbol's hex number
             if not pdf.strict:


### PR DESCRIPTION
This specific case I found was a document with a BaseFont named 'ABCDEE+\xef\xbc\xad\xef\xbc\xb3#20\xe6\x98\x8e\xe6\x9c\x9d'