### PR TITLE
utils.py changes

### DIFF
--- a/PyPDF2/merger.py
+++ b/PyPDF2/merger.py
@@ -28,7 +28,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from .generic import *
-from .utils import string_type, str_
+from .utils import isString, str_
 from .pdf import PdfFileReader, PdfFileWriter
 from .pagerange import PageRange
 from sys import version_info
@@ -109,7 +109,7 @@ class PdfFileMerger(object):
         # it is a PdfFileReader, copy that reader's stream into a
         # BytesIO (or StreamIO) stream.
         # If fileobj is none of the above types, it is not modified
-        if type(fileobj) == string_type:
+        if isString(fileobj):
             fileobj = file(fileobj, 'rb')
             my_file = True
         elif isinstance(fileobj, file):
@@ -205,7 +205,7 @@ class PdfFileMerger(object):
             file-like object.
         """
         my_file = False
-        if type(fileobj) in (str, str):
+        if isString(fileobj):
             fileobj = file(fileobj, 'wb')
             my_file = True
 

--- a/PyPDF2/pagerange.py
+++ b/PyPDF2/pagerange.py
@@ -8,7 +8,7 @@ see https://github.com/mstamy2/PyPDF2/blob/master/LICENSE
 """
 
 import re
-from .utils import Str
+from .utils import isString
 
 _INT_RE = r"(0|-?[1-9]\d*)"  # A decimal int, don't allow "-0".
 PAGE_RANGE_RE = "^({int}|({int}?(:{int}?(:{int}?)?)))$".format(int=_INT_RE)
@@ -68,7 +68,7 @@ class PageRange(object):
             self._slice = arg.to_slice()
             return
 
-        m = isinstance(arg, Str) and re.match(PAGE_RANGE_RE, arg)
+        m = isString(arg) and re.match(PAGE_RANGE_RE, arg)
         if not m:
             raise ParseError(arg)
         elif m.group(2):
@@ -89,7 +89,7 @@ class PageRange(object):
         """ True if input is a valid initializer for a PageRange. """
         return isinstance(input, slice)  or \
                isinstance(input, PageRange) or \
-               (isinstance(input, Str)
+               (isString(input)
                 and bool(re.match(PAGE_RANGE_RE, input)))
 
     def to_slice(self):

--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -63,7 +63,7 @@ import warnings
 import codecs
 from .generic import *
 from .utils import readNonWhitespace, readUntilWhitespace, ConvertFunctionsToVirtualList
-from .utils import Str, b_, u_, ord_, chr_, str_, string_type, formatWarning
+from .utils import isString, b_, u_, ord_, chr_, str_, formatWarning
 
 if version_info < ( 2, 4 ):
    from sets import ImmutableSet as frozenset
@@ -906,7 +906,7 @@ class PdfFileReader(object):
         self.xrefIndex = 0
         if hasattr(stream, 'mode') and 'b' not in stream.mode:
             warnings.warn("PdfFileReader stream/file object is not in binary mode. It may not be read correctly.", utils.PdfReadWarning)
-        if type(stream) in (string_type, str):
+        if isString(stream):
             fileobj = open(stream, 'rb')
             stream = BytesIO(b_(fileobj.read()))
             fileobj.close()
@@ -1167,7 +1167,7 @@ class PdfFileReader(object):
                     # for an example of such a file, see https://unglueit-files.s3.amazonaws.com/ebf/7552c42e9280b4476e59e77acc0bc812.pdf
                     # so continue to load the file without the Bookmarks
                     return outlines
-                    
+
                 if "/First" in lines:
                     node = lines["/First"]
             self._namedDests = self.getNamedDestinations()

--- a/PyPDF2/utils.py
+++ b/PyPDF2/utils.py
@@ -33,25 +33,35 @@ __author_email__ = "biziqe@mathieu.fenniak.net"
 
 
 import sys
-# "Str" maintains compatibility with Python 2.x.
-# The next line is obfuscated like this so 2to3 won't change it.
+
 try:
     import __builtin__ as builtins
 except ImportError:  # Py3
     import builtins
 
 
-if sys.version_info[0] < 3:
-    string_type = unicode
-    bytes_type = str
-    int_types = (int, long)
-else:
-    string_type = str
-    bytes_type = bytes
-    int_types = (int,)
+xrange_fn = getattr(builtins, "xrange", range)
+_basestring = getattr(builtins, "basestring", str)
 
-Xrange = getattr(builtins, "xrange", range)
-Str = getattr(builtins, "basestring", str)
+bytes_type = type(bytes()) # Works the same in Python 2.X and 3.X
+string_type = getattr(builtins, "unicode", str)
+int_types = (int, long) if sys.version_info[0] < 3 else (int,)
+
+
+# Make basic type tests more consistent
+def isString(s):
+    """Test if arg is a string. Compatible with Python 2 and 3."""
+    return isinstance(s, _basestring)
+
+
+def isInt(n):
+    """Test if arg is an int. Compatible with Python 2 and 3."""
+    return isinstance(n, int_types)
+
+
+def isBytes(b):
+    """Test if arg is a bytes instance. Compatible with Python 2 and 3."""
+    return isinstance(b, bytes_type)
 
 
 #custom implementation of warnings.formatwarning
@@ -141,10 +151,10 @@ class ConvertFunctionsToVirtualList(object):
 
     def __getitem__(self, index):
         if isinstance(index, slice):
-            indices = Xrange(*index.indices(len(self)))
+            indices = xrange_fn(*index.indices(len(self)))
             cls = type(self)
             return cls(indices.__len__, lambda idx: self[indices[idx]])
-        if not isinstance(index, int_types):
+        if not isInt(index):
             raise TypeError("sequence indices must be integers")
         len_self = len(self)
         if index < 0:


### PR DESCRIPTION
Fixes issue https://github.com/mstamy2/PyPDF2/issues/178

 - Adding functions isString(), isInt(), isBytes() to make type testing simpler and more consistent. Works for Python 2 and 3.
   - Note: "string_type", "bytes_type" and "int_types" are functionally unchanged: Made sure all references to these types were compatible with how things worked pre-fork.