### PR TITLE
Add hash (#) to list of odd escape sequences

### DIFF
--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -346,7 +346,7 @@ def readStringFromStream(stream):
                 tok = b_(")")
             elif tok == b_("\\"):
                 tok = b_("\\")
-            elif tok in (b_(" "), b_("/"), b_("%"), b_("<"), b_(">"), b_("["), b_("]")):
+            elif tok in (b_(" "), b_("/"), b_("%"), b_("<"), b_(">"), b_("["), b_("]"), b_("#")):
                 # odd/unnessecary escape sequences we have encountered
                 tok = b_(tok)
             elif tok.isdigit():


### PR DESCRIPTION
I have recently been getting "Unexpected escaped string" for some PDFs. Unfortunately I can't share this PDFs but adding the hash sign to the list of escape sequences fixes the problem.

I believe this was the sequence causing the exception in my pdf `<< /Type /OCG /Name (1318-A-121\ SiteTrees\#1_Pen_No__1)`