### PR TITLE
Overflow error in generic.py

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
-﻿Version 1.24, 2014-12-31
+﻿Version 1.24, 2015-3-13
+------------------------
+ - Overflow error in generic.py (by Raja Jamwal)
+ 
+Version 1.24, 2014-12-31
 ------------------------
 
  - Bugfixes for reading files in Python 3 (by Anthony Tuininga and

--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -43,6 +43,7 @@ from . import filters
 from . import utils
 import decimal
 import codecs
+import sys
 #import debugging
 
 ObjectPrefix = b_('/<[tf(n%')
@@ -248,7 +249,8 @@ class NumberObject(int, PdfObject):
     ByteDot = b_(".")
 
     def __new__(cls, value):
-        return int.__new__(cls, value)
+        val = int (0) if int(value)>int(sys.maxint) else int(value)
+        return int.__new__(cls, val)
 
     def as_numeric(self):
         return int(b_(repr(self)))


### PR DESCRIPTION
Some PDF returned value greater than size of long, therefore Overflow error in generic.py, This leads to Overflow exception, OverflowError:python int too large to convert to C long
Example PDF here for review, https://www.dropbox.com/s/eibno2yoornalxg/Drawing%20deadman%20anchor.pdf?dl=0