### PR TITLE
Fix "file has not been decrypted" error #51.

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -973,6 +973,7 @@ class PdfFileReader(object):
         if self.isEncrypted:
             try:
                 self._override_encryption = True
+                self.decrypt('')
                 return self.trailer["/Root"]["/Pages"]["/Count"]
             except:
                 raise utils.PdfReadError("File has not been decrypted")


### PR DESCRIPTION
Workaround for PDFs which behave as if decrypted, though were 
encrypted without a password.

This occasional bug dates back to here: https://bugs.launchpad.net/pypdf/+bug/355479 

Basically the PDFs have been encrypted incorrectly and for most purposes invisibly (other applications used to handle these PDFs have built-in exception and don't require explicit decryption with no password), so this tends to cause bad user experience in trying to work out this PyPDF2 bug.

In my case it was bank-generated bank statements that otherwise behave as unencrypted, no password is required to view or manipulate them, it was only be caught by PyPDF2. This workaround allows PyPDF2 to do batch processing of these types of files without borking on every one.

Non encrypted PDFs aren't affected.