### PR TITLE
Separate extracted text fields with EOLs

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -2543,6 +2543,7 @@ class PageObject(DictionaryObject):
                 for i in operands[0]:
                     if isinstance(i, TextStringObject):
                         text += i
+                text += "\n"
         return text
 
     mediaBox = createRectangleAccessor("/MediaBox", ())


### PR DESCRIPTION
Each "TJ" entry is a separate piece of text so provide some way for the user to separate them in the extracted text. This way the user can then txt.split("\n") to get a list of all text blocks