### PR TITLE
Add abbreviated short-names for filters

### DIFF
--- a/PyPDF2/filters.py
+++ b/PyPDF2/filters.py
@@ -318,13 +318,13 @@ def decodeStreamData(stream):
     # If there is not data to decode we should not try to decode the data.
     if data:
         for filterType in filters:
-            if filterType == "/FlateDecode":
+            if filterType == "/FlateDecode" or filterType == "/Fl":
                 data = FlateDecode.decode(data, stream.get("/DecodeParms"))
-            elif filterType == "/ASCIIHexDecode":
+            elif filterType == "/ASCIIHexDecode" or filterType == "/AHx":
                 data = ASCIIHexDecode.decode(data)
-            elif filterType == "/LZWDecode":
+            elif filterType == "/LZWDecode" or filterType == "/LZW":
                 data = LZWDecode.decode(data, stream.get("/DecodeParms"))
-            elif filterType == "/ASCII85Decode":
+            elif filterType == "/ASCII85Decode" or filterType == "/A85":
                 data = ASCII85Decode.decode(data)
             elif filterType == "/Crypt":
                 decodeParams = stream.get("/DecodeParams", {})


### PR DESCRIPTION
After investigating an odd error:

`NotImplementedError: unsupported filter /Fl`

I saw the PDF had this line:

`<</Filter/Fl/First 12/Length 828/N 2/Type/ObjStm>>stream`

But most objects had:

`<</Size 306/Filter/FlateDecode/Length 947/Type/XRef/W[1 3 1]`

After looking at the filters.py file, I saw the short-names were not added. After modifying the filters.py, the code is up and running again.

A thanks to Matthew Weiss for helping with this as well.