### PR TITLE
Added decryption key copying for PdfFileMerger

### DIFF
--- a/PyPDF2/merger.py
+++ b/PyPDF2/merger.py
@@ -109,6 +109,7 @@ class PdfFileMerger(object):
         # it is a PdfFileReader, copy that reader's stream into a
         # BytesIO (or StreamIO) stream.
         # If fileobj is none of the above types, it is not modified
+        decryption_key = None
         if isString(fileobj):
             fileobj = file(fileobj, 'rb')
             my_file = True
@@ -123,11 +124,15 @@ class PdfFileMerger(object):
             filecontent = StreamIO(fileobj.stream.read())
             fileobj.stream.seek(orig_tell) # reset the stream to its original location
             fileobj = filecontent
+            if hasattr(fileobj, '_decryption_key'):
+                decryption_key = fileobj._decryption_key
             my_file = True
 
         # Create a new PdfFileReader instance using the stream
         # (either file or BytesIO or StringIO) created above
         pdfr = PdfFileReader(fileobj, strict=self.strict)
+        if decryption_key is not None:
+            pdfr._decryption_key = decryption_key
 
         # Find the range of pages to merge.
         if pages == None:


### PR DESCRIPTION
We are concatenating PDFs from users and ran into an issue with one of them being encrypted. Following the advice from #51, we used `decrypt` and got a `PdfFileReader` working. However, we were unable to merge in the decrypted PDF to `PdfFileMerger` as it creates a new object which loses the decryption key.

In order to keep things simple and not mutate any underlying streams, we decided to copy over the `_decryption_key` upon merge. In this PR:

- Added `_decryption_key` copying to `PdfFileReader` clone in `PdfFileMerger`