### PR TITLE
Fix "Stream has ended unexpectedly" for Name Objects

### DIFF
--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -461,7 +461,7 @@ class TextStringObject(utils.string_type, PdfObject):
 
 
 class NameObject(str, PdfObject):
-    delimiterPattern = re.compile(b_(r"\s+|[()<>[\]{}/%]"))
+    delimiterPattern = re.compile(b_(r"\s+|[\(\)<>\[\]{}/%]"))
     surfix = b_("/")
 
     def writeToStream(self, stream, encryption_key):

--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -461,7 +461,7 @@ class TextStringObject(utils.string_type, PdfObject):
 
 
 class NameObject(str, PdfObject):
-    delimiterPattern = re.compile(b_("\s+|[()<>[\]{}/%]"))
+    delimiterPattern = re.compile(b_(r"\s+|[()<>[\]{}/%]"))
     surfix = b_("/")
 
     def writeToStream(self, stream, encryption_key):
@@ -473,7 +473,8 @@ class NameObject(str, PdfObject):
         name = stream.read(1)
         if name != NameObject.surfix:
             raise utils.PdfReadError("name read error")
-        name += utils.readUntilRegex(stream, NameObject.delimiterPattern)
+        name += utils.readUntilRegex(stream, NameObject.delimiterPattern, 
+            ignore_eof=True)
         if debug: print(name)
         try:
             return NameObject(name.decode('utf-8'))


### PR DESCRIPTION
Fix a bug which could result in a "Stream has ended unexpectedly" error being raised unnecessarily if a Name object runs right up against the end of a file stream.

I have a test case, but it's unfortunately very convoluted and will be quite difficult for me to get running in PyPDF. However, if one could somehow make a PDF with a inline stream object, and a Name object at the very end of the stream, then it would trigger this bug fix (not sure how to do that).