### PR TITLE
Parameterized JavaScript.

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -46,6 +46,7 @@ import string
 import math
 import struct
 import sys
+import uuid
 from sys import version_info
 if version_info < ( 3, 0 ):
     from cStringIO import StringIO
@@ -227,14 +228,20 @@ class PdfFileWriter(object):
                 })
         js_indirect_object = self._addObject(js)
 
-        js_name_tree = DictionaryObject({
-                NameObject("/Names"): ArrayObject([createStringObject('0000000000'), js_indirect_object])
+        # We need a name for parameterized javascript in the pdf file, but it can be anything.
+        js_string_name = str(uuid.uuid4())
+
+        js_name_tree = DictionaryObject()
+        js_name_tree.update({
+                NameObject("/JavaScript"): DictionaryObject({
+                  NameObject("/Names"): ArrayObject([createStringObject(js_string_name), js_indirect_object])
                 })
+              })
+        self._addObject(js_name_tree)
+
         self._root_object.update({
                 NameObject("/OpenAction"): js_indirect_object,
-                NameObject("/Names"): DictionaryObject({
-                    NameObject("/JavaScript"): js_name_tree
-                    })
+                NameObject("/Names"): js_name_tree
                 })
 
     def addAttachment(self, fname, fdata):

--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -225,8 +225,16 @@ class PdfFileWriter(object):
                 NameObject("/S"): NameObject("/JavaScript"),
                 NameObject("/JS"): NameObject("(%s)" % javascript)
                 })
+        js_indirect_object = self._addObject(js)
+
+        js_name_tree = DictionaryObject({
+                NameObject("/Names"): ArrayObject([createStringObject('0000000000'), js_indirect_object])
+                })
         self._root_object.update({
-                NameObject("/OpenAction"): self._addObject(js)
+                NameObject("/OpenAction"): js_indirect_object,
+                NameObject("/Names"): DictionaryObject({
+                    NameObject("/JavaScript"): js_name_tree
+                    })
                 })
 
     def addAttachment(self, fname, fdata):

--- a/Tests/tests.py
+++ b/Tests/tests.py
@@ -1,4 +1,9 @@
-import os, sys, unittest
+import os
+import sys
+import unittest
+
+from PyPDF2 import PdfFileReader, PdfFileWriter
+
 
 # Configure path environment
 TESTS_ROOT = os.path.abspath(os.path.dirname(__file__))
@@ -7,29 +12,58 @@ RESOURCE_ROOT = os.path.join(PROJECT_ROOT, 'Resources')
 
 sys.path.append(PROJECT_ROOT)
 
-# Test imports
-import unittest
-from PyPDF2 import PdfFileReader
-
 
 class PdfReaderTestCases(unittest.TestCase):
 
-	def test_PdfReaderFileLoad(self):
-		'''	Test loading and parsing of a file. Extract text of the file and compare to expected
-			textual output. Expected outcome: file loads, text matches expected.
-		'''
-		with open(os.path.join(RESOURCE_ROOT, 'crazyones.pdf'), 'rb') as inputfile:
-			
-			# Load PDF file from file
-			ipdf = PdfFileReader(inputfile)
-			ipdf_p1 = ipdf.getPage(0)
-			
-			# Retrieve the text of the PDF
-			pdftext_file = open(os.path.join(RESOURCE_ROOT, 'crazyones.txt'), 'r')
-			pdftext = pdftext_file.read()
-			ipdf_p1_text = ipdf_p1.extractText()
-			
-			# Compare the text of the PDF to a known source
-			self.assertEqual(ipdf_p1_text.encode('utf-8', errors='ignore'), pdftext,
-				msg='PDF extracted text differs from expected value.\n\nExpected:\n\n%r\n\nExtracted:\n\n%r\n\n'
-					% (pdftext, ipdf_p1_text.encode('utf-8', errors='ignore')))
+    def test_PdfReaderFileLoad(self):
+        '''
+        Test loading and parsing of a file. Extract text of the file and compare to expected
+        textual output. Expected outcome: file loads, text matches expected.
+        '''
+
+        with open(os.path.join(RESOURCE_ROOT, 'crazyones.pdf'), 'rb') as inputfile:
+            # Load PDF file from file
+            ipdf = PdfFileReader(inputfile)
+            ipdf_p1 = ipdf.getPage(0)
+
+            # Retrieve the text of the PDF
+            pdftext_file = open(os.path.join(RESOURCE_ROOT, 'crazyones.txt'), 'r')
+            pdftext = pdftext_file.read()
+            ipdf_p1_text = ipdf_p1.extractText().replace('\n', '')
+
+            # Compare the text of the PDF to a known source
+            self.assertEqual(ipdf_p1_text.encode('utf-8', errors='ignore'), pdftext,
+                msg='PDF extracted text differs from expected value.\n\nExpected:\n\n%r\n\nExtracted:\n\n%r\n\n'
+                    % (pdftext, ipdf_p1_text.encode('utf-8', errors='ignore')))
+
+
+class AddJsTestCase(unittest.TestCase):
+
+    def setUp(self):
+        ipdf = PdfFileReader(os.path.join(RESOURCE_ROOT, 'crazyones.pdf'))
+        self.pdf_file_writer = PdfFileWriter()
+        self.pdf_file_writer.appendPagesFromReader(ipdf)
+
+    def test_add(self):
+
+        self.pdf_file_writer.addJS("this.print({bUI:true,bSilent:false,bShrinkToFit:true});")
+
+        self.assertIn('/Names', self.pdf_file_writer._root_object, "addJS should add a name catalog in the root object.")
+        self.assertIn('/JavaScript', self.pdf_file_writer._root_object['/Names'], "addJS should add a JavaScript name tree under the name catalog.")
+        self.assertIn('/OpenAction', self.pdf_file_writer._root_object, "addJS should add an OpenAction to the catalog.")
+
+    def test_overwrite(self):
+
+        self.pdf_file_writer.addJS("this.print({bUI:true,bSilent:false,bShrinkToFit:true});")
+        first_js = self.get_javascript_name()
+
+        self.pdf_file_writer.addJS("this.print({bUI:true,bSilent:false,bShrinkToFit:true});")
+        second_js = self.get_javascript_name()
+
+        self.assertNotEqual(first_js, second_js, "addJS should overwrite the previous script in the catalog.")
+
+    def get_javascript_name(self):
+        self.assertIn('/Names', self.pdf_file_writer._root_object)
+        self.assertIn('/JavaScript', self.pdf_file_writer._root_object['/Names'])
+        self.assertIn('/Names', self.pdf_file_writer._root_object['/Names']['/JavaScript'])
+        return self.pdf_file_writer._root_object['/Names']['/JavaScript']['/Names'][0]


### PR DESCRIPTION
According to the PDF doc, an entry in the document's name dictionary,
listing the JavaScript actions, is required to execute parameterized
function call.

Also note that:
> The names are arbitrary and need not bear any relation to the
> JavaScript name
> space.

In this case, the name is a random string (using uuid).