### PR TITLE
Pageobject.mergePage() fails for some pages with images (Python3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.swp
 .DS_Store
 build
+.idea/*
+

--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -2724,14 +2724,14 @@ class ContentStream(DecodedStreamObject):
     def _getData(self):
         newdata = BytesIO()
         for operands, operator in self.operations:
-            if operator == "INLINE IMAGE":
-                newdata.write("BI")
-                dicttext = StringIO()
+            if operator == b_("INLINE IMAGE"):
+                newdata.write(b_("BI"))
+                dicttext = BytesIO()
                 operands["settings"].writeToStream(dicttext, None)
                 newdata.write(dicttext.getvalue()[2:-2])
-                newdata.write("ID ")
+                newdata.write(b_("ID "))
                 newdata.write(operands["data"])
-                newdata.write("EI")
+                newdata.write(b_("EI"))
             else:
                 for op in operands:
                     op.writeToStream(newdata, None)


### PR DESCRIPTION
This is fix for https://github.com/mstamy2/PyPDF2/issues/176
I have a document for which it is possible to reproduce the issue but it is copyrighted so I haven't included it in unittests. I can provide the document on demand. Seems that the bug involves .eps vector images.