### PR TITLE
Try to handle pdf with invalid stream length

### DIFF
--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -623,9 +623,18 @@ class DictionaryObject(dict, PdfObject):
                     # we found it by looking back one character further.
                     data["__streamdata__"] = data["__streamdata__"][:-1]
                 else:
-                    if debug: print(("E", e, ndstream, debugging.toHex(end)))
-                    stream.seek(pos, 0)
-                    raise utils.PdfReadError("Unable to find 'endstream' marker after stream at byte %s." % utils.hexStr(stream.tell()))
+                    # Handle pdf files with bit too short stream length
+                    stream.seek(t + length, 0)
+                    extra = stream.read(50)
+                    p = extra.find(b_("endstream"))
+                    if p >= 0:
+                        stream.seek(t + length + p + 9, 0)
+                        extra = extra[:p].rstrip(b_('\r\n '))
+                        data["__streamdata__"] = data["__streamdata__"] + extra
+                    else:
+                        if debug: print(("E", e, ndstream, debugging.toHex(end)))
+                        stream.seek(pos, 0)
+                        raise utils.PdfReadError("Unable to find 'endstream' marker after stream at byte %s." % utils.hexStr(stream.tell()))
         else:
             stream.seek(pos, 0)
         if "__streamdata__" in data:


### PR DESCRIPTION
I have some pdf files from some unknown old CAD program that have a bit longer stream than the stream's dictionary says. Currently I have a file with difference of just one byte, but my code tries to handle difference up to 41 bytes. This PR fixes this issue by trying to find the missing "endstream" marker from the following content and assuming that the length in dictionary is incorrect.

I have tested that this code works on Python 2.7, but not on Python 3.