### PR TITLE
Fix a bug in _readInlineImage

### DIFF
--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -234,8 +234,12 @@ class FloatObject(decimal.Decimal, PdfObject):
         if self == self.to_integral():
             return str(self.quantize(decimal.Decimal(1)))
         else:
-            # XXX: this adds useless extraneous zeros.
-            return "%.5f" % self
+            # Standard formatting adds useless extraneous zeros.
+            o = "%.5f" % self
+            # Remove the zeros.
+            while o and o[-1] == '0':
+                o = o[:-1]
+            return o
 
     def as_numeric(self):
         return float(b_(repr(self)))

--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -2731,13 +2731,16 @@ class ContentStream(DecodedStreamObject):
                 # Check for End Image
                 tok2 = stream.read(1)
                 if tok2 == b_("I"):
-                    # Sometimes that data will contain EI, so check for the Q operator.
+                    # Data can contain EI, so check for the Q operator.
                     tok3 = stream.read(1)
                     info = tok + tok2
+                    # We need to find whitespace between EI and Q.
+                    has_q_whitespace = False
                     while tok3 in utils.WHITESPACES:
+                        has_q_whitespace = True
                         info += tok3
                         tok3 = stream.read(1)
-                    if tok3 == b_("Q"):
+                    if tok3 == b_("Q") and has_q_whitespace:
                         stream.seek(-1, 1)
                         break
                     else:


### PR DESCRIPTION
_readInlineImage fails for any image that has "EIQ" inside of it.

In the in function `_readInlineImage`, we were looking for the operation `EI` and `Q`.  However, we were not checking to ensure that there was whitespace between `EI` and `Q`. Accordingly, any image that had `EIQ` in its ascii encoded data would trigger the end of the image, and cause errors.

This fix changes that.

Also, added a small nit change to remove extraneous zeros from our output formatting. These can needlessly bloat the size of the PDF and hurt readability.
