### PR TITLE
Added LICENSE to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include CHANGELOG
+include LICENSE


### PR DESCRIPTION
For the [conda-forge build](https://github.com/conda-forge/pypdf2-feedstock/), we'd like to include a copy of the license file. Doing so requires that the license be explicitly included in `MANIFEST.in` so that it gets bundled with the source build.
