### PR TITLE
Fix PdfFileMerger for file objects on Python 3.

### DIFF
--- a/PyPDF2/merger.py
+++ b/PyPDF2/merger.py
@@ -113,7 +113,7 @@ class PdfFileMerger(object):
         if isString(fileobj):
             fileobj = file(fileobj, 'rb')
             my_file = True
-        elif isinstance(fileobj, file):
+        elif hasattr(fileobj, "seek") and hasattr(fileobj, "read"):
             fileobj.seek(0)
             filecontent = fileobj.read()
             fileobj = StreamIO(filecontent)


### PR DESCRIPTION
The previous check was always evaluated to False on Python 3, which led to generating blank pages in output PDF. I replaced it with a duck-typing check compatible with Python 2 and 3.

The issue has been described here: https://github.com/mstamy2/PyPDF2/issues/293
