### PR TITLE
pip install instructions added

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Please see the `Sample_Code` folder.
 Documentation is available at  
 https://pythonhosted.org/PyPDF2/
 
+##Installation
+
+To install via pip:
+
+`pip install PyPDF2`
 
 ##FAQ
 Please see  


### PR DESCRIPTION
README is lacking installation instructions. This should help.