### PR TITLE
Fix issue #337 - Rotate PDF fails if /Rotate is set to an IndirectObject

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -2226,7 +2226,8 @@ class PageObject(DictionaryObject):
         return self
 
     def _rotate(self, angle):
-        currentAngle = self.get("/Rotate", 0)
+        rotateObj = self.get("/Rotate", 0)
+        currentAngle = rotateObj if isinstance(rotateObj, int) else rotateObj.getObject()
         self[NameObject("/Rotate")] = NumberObject(currentAngle + angle)
 
     def _mergeResources(res1, res2, resource):


### PR DESCRIPTION
update _rotate function to account for /Rotate being set to an IndirectObject instead of an int