### PR TITLE
Handles exception thrown by data.pdf.getObject

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -589,7 +589,7 @@ class PdfFileWriter(object):
                         newobj = self._sweepIndirectReferences(externMap, newobj)
                         self._objects[idnum-1] = newobj
                         return newobj_ido
-                    except ValueError:
+                    except (ValueError, utils.PdfReadError):
                         # Unable to resolve the Object, returning NullObject instead.
                         warnings.warn("Unable to resolve [{}: {}], returning NullObject instead".format(
                             data.__class__.__name__, data


### PR DESCRIPTION
Trying to copying a "corrupted" PDF file into a new file was throwing the Exception utils.PdfReadError("Could not find object."), and the application was unable to make the actual copy. This corrupted PDF, however, would work just fine in Acrobat and other PDF viewers. 

My  take on the issue is that my file contained a reference to a resource/object that was removed and no longer existed. If the object no longer exist, I am sure, it is safe to ignore when copying. 

This is a snippet of the code I was using to copy the file. Although I was modifying the file metadata, the error would still be there even without modifying the metadata.

```
        original_pdf = PdfFileReader(save_path, strict=False)
        original_pdf_meta_data = get_metadata(original_pdf)
        original_pdf_title = original_pdf_meta_data.get('/Title', '')
        if original_pdf_title != metadata.get('/Title'):
            logger.debug("Creating a new PDF file with updated metadata for "
                         "publication {}".format(pub_busid))
            # only write the new metadata if we are changing it
            output_pdf = PdfFileWriter()
            for page in range(original_pdf.getNumPages()):
                output_pdf.addPage(original_pdf.getPage(page))
            # save updated PDF to temp location
            with open(temp_path, 'wb') as outstream:
                output_pdf.addMetadata(metadata)
                output_pdf.setPageLayout('/SinglePage')
                output_pdf.write(outstream)
                logger.debug('The PDF Metadata has been updated for "{}"'.format(save_path))
```