### PR TITLE
Updated docstring for Destination class

### DIFF
--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -355,7 +355,7 @@ def readStringFromStream(stream):
                            b_("%") : b_("%"),
                            b_("<") : b_("<"),
                            b_(">") : b_(">"),
-                           b_("[") : b_("["), 
+                           b_("[") : b_("["),
                            b_("]") : b_("]"),
                            b_("#") : b_("#"),
                            b_("_") : b_("_"),
@@ -479,7 +479,7 @@ class NameObject(str, PdfObject):
         name = stream.read(1)
         if name != NameObject.surfix:
             raise utils.PdfReadError("name read error")
-        name += utils.readUntilRegex(stream, NameObject.delimiterPattern, 
+        name += utils.readUntilRegex(stream, NameObject.delimiterPattern,
             ignore_eof=True)
         if debug: print(name)
         try:
@@ -1029,7 +1029,8 @@ class Destination(TreeObject):
     See section 8.2.1 of the PDF 1.6 reference.
 
     :param str title: Title of this destination.
-    :param int page: Page number of this destination.
+    :param IndirectObject page: Reference to the page of this destination. Should
+        be an instance of :class:`IndirectObject<PyPDF2.generic.IndirectObject>`.
     :param str typ: How the destination is displayed.
     :param args: Additional arguments may be necessary depending on the type.
     :raises PdfReadError: If destination type is invalid.


### PR DESCRIPTION
The constructor expects the page argument to be a reference to a page (`IndirectObject`), rather than the integer index of the page in the document. This change updates the docs for the class.

Also, my editor removed a couple of trailing spaces. Let me know and I'll remove those changes if you'd rather they weren't included here.