### PR TITLE
Fixed extractText()-Not returning text with spaces

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -2683,6 +2683,7 @@ class PageObject(DictionaryObject):
             elif operator == b_("TJ"):
                 for i in operands[0]:
                     if isinstance(i, TextStringObject):
+                        text += " "
                         text += i
                 text += "\n"
         return text


### PR DESCRIPTION
**Previously the function `.extractText()` reads the text in the PDF and returns without any spaces.
In this fix the pdf.py file has been modified to add " " (space) in between two words**

_Here is an example below:_-
**Original Sentence :** `"The quick brown fox jumps over the lazy dog"`

**Previous Output :** `"Thequickbrownfoxjumpsoverthelazydog"`

**Output After fix :**` "The quick brown fox jumps over the lazy dog"`