### PR TITLE
Use setuptools instead of distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 import re
 
 long_description = """


### PR DESCRIPTION
This allows the project to make use of modern Python packaging features such as wheels, isolated builds, and more.

The change is also going to be necessary soon; distutils will soon be deprecated in 3.10, and removed from the standard library in 3.12.