### PR TITLE
Fix formatWarning for filename without slash

### DIFF
--- a/PyPDF2/utils.py
+++ b/PyPDF2/utils.py
@@ -66,7 +66,7 @@ def isBytes(b):
 
 #custom implementation of warnings.formatwarning
 def formatWarning(message, category, filename, lineno, line=None):
-    file = filename.replace("/", "\\").rsplit("\\", 1)[1] # find the file name
+    file = filename.replace("/", "\\").rsplit("\\", 1)[-1] # find the file name
     return "%s: %s [%s:%s]\n" % (category.__name__, message, file, lineno)
 
 


### PR DESCRIPTION
formatWarning does fail if the filename does not contain a path.

You can reproduce this with:

```
from PyPDF2.utils import formatWarning
formatWarning('message', DeprecationWarning, 'filename', 100)
```