### PR TITLE
Filename issue in formatWarning method in utils.py

### DIFF
--- a/PyPDF2/utils.py
+++ b/PyPDF2/utils.py
@@ -66,7 +66,7 @@ def isBytes(b):
 
 #custom implementation of warnings.formatwarning
 def formatWarning(message, category, filename, lineno, line=None):
-    file = filename.replace("/", "\\").rsplit("\\", 1)[1] # find the file name
+    file = filename.replace("/", "\\").split('\\')[-1] # find the file name
     return "%s: %s [%s:%s]\n" % (category.__name__, message, file, lineno)
 
 

--- a/PyPDF2/utils.py
+++ b/PyPDF2/utils.py
@@ -66,7 +66,7 @@ def isBytes(b):
 
 #custom implementation of warnings.formatwarning
 def formatWarning(message, category, filename, lineno, line=None):
-    file = filename.replace("/", "\\").split('\\')[-1] # find the file name
+    file = filename.replace("/", "\\").split('\\').pop() # find the file name
     return "%s: %s [%s:%s]\n" % (category.__name__, message, file, lineno)
 
 


### PR DESCRIPTION
I have created a pull request to address the `IndexError` which arises when `formatWarning()` in **utils.py** is passed a `filename` string that doesn't contain a `/` or `\\` character. I simply implemented @CrimsonZen's suggestion of replacing:
`file = filename.replace("/","\\").rsplit("\\",1)[1] # find the file name`
with
`file = filename.replace("/","\\").rsplit("\\",1).pop() # find the file name` 

Hopefully this can be merged into the main branch at some point. This error arises because PyPDF2 overwrites `warnings.formatwarning` (issue #67). However, this pull request does not address the issue directly. 