### PR TITLE
BUG: Stream operations can be List or Dict

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -47,6 +47,7 @@ import math
 import struct
 import sys
 import uuid
+import types
 from sys import version_info
 if version_info < ( 3, 0 ):
     from cStringIO import StringIO
@@ -2255,10 +2256,18 @@ class PageObject(DictionaryObject):
             return stream
         stream = ContentStream(stream, pdf)
         for operands, _operator in stream.operations:
-            for i in range(len(operands)):
-                op = operands[i]
-                if isinstance(op, NameObject):
-                    operands[i] = rename.get(op,op)
+            if type (operands) == types.ListType:
+                for i in range(len(operands)):
+                    op = operands[i]
+                    if isinstance(op, NameObject):
+                        operands[i] = rename.get(op,op)
+            elif type (operands) == types.DictType:
+                for i in operands:
+                    op = operands[i]
+                    if isinstance(op, NameObject):
+                        operands[i] = rename.get(op,op)
+            else:
+                raise KeyError ("type of operands is %s" % type (operands))
         return stream
     _contentStreamRename = staticmethod(_contentStreamRename)
 

--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -47,7 +47,6 @@ import math
 import struct
 import sys
 import uuid
-import types
 from sys import version_info
 if version_info < ( 3, 0 ):
     from cStringIO import StringIO
@@ -2256,12 +2255,12 @@ class PageObject(DictionaryObject):
             return stream
         stream = ContentStream(stream, pdf)
         for operands, _operator in stream.operations:
-            if type (operands) == types.ListType:
+            if isinstance(operands, list):
                 for i in range(len(operands)):
                     op = operands[i]
                     if isinstance(op, NameObject):
                         operands[i] = rename.get(op,op)
-            elif type (operands) == types.DictType:
+            elif isinstance(operands, dict):
                 for i in operands:
                     op = operands[i]
                     if isinstance(op, NameObject):


### PR DESCRIPTION
Appeared when merging PDFs that have
content-stream-inline images

This patch was provided by Georg Graf :
https://github.com/mstamy2/PyPDF2/issues/196#issuecomment-172829990
Thank you!

Closes #196