### PR TITLE
TST: Test Python 2.7

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2
@@ -23,14 +23,29 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+
+    - name: Upgrade pip
       run: |
         python -m pip install --upgrade pip
+
+    - name: Install requirements (python 3)
+      if: matrix.python-version != '2.7'
+      run: |
         pip install -r requirements/ci.txt
+    - name: Install requirements (python 2)
+      if: matrix.python-version == '2.7'
+      run: |
+        pip install pillow pytest pytest-cov
+
+    - name: Install module
+      run: |
         pip install .
+
     - name: Test with flake8
       run: |
         flake8 . --ignore E,F,I,SIM,C,PT,N,ASS,A,P,R,W
+      if: matrix.python-version != '2.7'
+
     - name: Test with pytest
       run: |
         pytest Tests/tests.py Tests --cov --cov-report term-missing -vv

--- a/Tests/test_workflows.py
+++ b/Tests/test_workflows.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import os
 import binascii
 import sys


### PR DESCRIPTION
Similar to #667, while we are still publishing 1.x releases, good to have testing. Once move to work for 2.0, I would suggest branching the current `master` into a long lived `1.x` branch, and then can remove this test stuff as 2.0 will drop python2 support.